### PR TITLE
Update inc.Settings.php

### DIFF
--- a/inc/inc.Settings.php
+++ b/inc/inc.Settings.php
@@ -76,6 +76,7 @@ if(isset($settings->_extraPath))
 if(isset($settings->_maxExecutionTime))
 	ini_set('max_execution_time', $settings->_maxExecutionTime);
 
+/* removed from PHP 8.0, no longer required from PHP5.4 as slashes no longer added
 if (get_magic_quotes_gpc()) {
 	$process = array(&$_GET, &$_POST, &$_COOKIE, &$_REQUEST);
 	while (list($key, $val) = each($process)) {
@@ -91,6 +92,7 @@ if (get_magic_quotes_gpc()) {
 	}
 	unset($process);
 }
+*/
 
 if($settings->_enableFullSearch) {
 	if($settings->_fullSearchEngine == 'sqlitefts') {

--- a/op/op.Login.php
+++ b/op/op.Login.php
@@ -57,9 +57,9 @@ if (!isset($login) || strlen($login)==0) {
 $pwd = '';
 if(isset($_POST['pwd'])) {
 	$pwd = (string) $_POST["pwd"];
-	if (get_magic_quotes_gpc()) {
+/*	if (get_magic_quotes_gpc()) {
 		$pwd = stripslashes($pwd);
-	}
+	} */
 }
 
 if($settings->_enableGuestLogin && (int) $settings->_guestID) {


### PR DESCRIPTION
get_magic_quotes_gpc() has been removed from PHP in version 8.0. Since v5.4 PHP no longer adds slashes to request parameters the function is always negative so there is no need to determine what to do if positive.